### PR TITLE
fix: remove topP from default inference config to support Claude 4.5+…

### DIFF
--- a/lambda/lib/aws/services/bedrock-service.ts
+++ b/lambda/lib/aws/services/bedrock-service.ts
@@ -36,7 +36,6 @@ export class BedrockService {
   // Fixed value settings
   private readonly DEFAULT_MAX_TOKENS = 8192;
   private readonly DEFAULT_TEMPERATURE = 0.1;
-  private readonly DEFAULT_TOP_P = 0.97;
   private readonly DEFAULT_KB_RESULTS = 3;
   
   /**
@@ -68,7 +67,6 @@ export class BedrockService {
     inferenceConfig: InferenceConfiguration = {
       maxTokens: this.DEFAULT_MAX_TOKENS,
       temperature: this.DEFAULT_TEMPERATURE,
-      topP: this.DEFAULT_TOP_P
     }
   ): Promise<string> {
     // Use provided model ID or get from configuration service


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
## Summary
Remove `topP` from default inference configuration in `BedrockService.converse()`.

## Problem
Claude 4.5+ models (including Sonnet 4.5, Haiku 4.5, Sonnet 4.6) do not allow specifying both `temperature` and `top_p` simultaneously, resulting in a `ValidationException`.

## Fix
Removed `topP: 0.97` from the default `inferenceConfig`, keeping only `temperature: 0.1`. This aligns with the AWS documentation recommendation to use either `temperature` or `top_p`, not both.

## Impact
- No breaking changes for older models (Claude 3 series)
- Fixes compatibility with Claude 4.5+ models
- All 3 callers of `converse()` use the default config, so no other changes needed

## Reference
https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-request-response.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
